### PR TITLE
add warm reboot support for fgnhg

### DIFF
--- a/orchagent/fgnhgorch.cpp
+++ b/orchagent/fgnhgorch.cpp
@@ -749,7 +749,12 @@ bool FgNhgOrch::set_new_nhg_members(FGNextHopGroupEntry &syncd_fg_route_entry, F
             if (is_warm_reboot)
             {
                 bank_nh_memb = nexthopsMap->second[j];
-                SWSS_LOG_NOTICE("Recovering nexthop %s with bucket %d", bank_nh_memb.ip_address.to_string().c_str(), j);
+                SWSS_LOG_INFO("Recovering nexthop %s with bucket %d", bank_nh_memb.ip_address.to_string().c_str(), j);
+                // case nhps in bank are all down
+                if (fgNhgEntry->nextHops[bank_nh_memb.ip_address] != i)
+                {
+                	syncd_fg_route_entry.inactive_to_active_map[i] = fgNhgEntry->nextHops[bank_nh_memb.ip_address];
+                }
             }
             else
             {

--- a/orchagent/fgnhgorch.h
+++ b/orchagent/fgnhgorch.h
@@ -71,6 +71,7 @@ typedef struct
 } Bank_Member_Changes;
 
 typedef std::vector<string> NextHopIndexMap;
+typedef map<string, NextHopIndexMap> WarmBootRecoveryMap;
 
 class FgNhgOrch : public Orch
 {
@@ -95,8 +96,8 @@ private:
     Table m_stateWarmRestartRouteTable;
 
     // warm reboot support for recovery
-    // < ip_prefix, < ip_next_hop, HashBuckets>>
-    map<string, NextHopIndexMap> m_recoveryMap;
+    // < ip_prefix, < HashBuckets, nh_ip>>
+    WarmBootRecoveryMap m_recoveryMap;
 
     bool set_new_nhg_members(FGNextHopGroupEntry &syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
                     std::vector<Bank_Member_Changes> &bank_member_changes, 

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -127,13 +127,13 @@ bool OrchDaemon::init()
     gIntfsOrch = new IntfsOrch(m_applDb, APP_INTF_TABLE_NAME, vrf_orch);
     gNeighOrch = new NeighOrch(m_applDb, APP_NEIGH_TABLE_NAME, gIntfsOrch);
 
-    /* TODO: add table priorities to fgnhg_tables: table_name_with_pri_t after checking what is the implication of it */
-    vector<string> fgnhg_tables = {
-        CFG_FG_NHG,
-        CFG_FG_NHG_PREFIX,
-        CFG_FG_NHG_MEMBER
-    };
+    const int fgnhgorch_pri = 15;
 
+    vector<table_name_with_pri_t> fgnhg_tables = {
+        { CFG_FG_NHG,                 fgnhgorch_pri },
+        { CFG_FG_NHG_PREFIX,          fgnhgorch_pri },
+        { CFG_FG_NHG_MEMBER,          fgnhgorch_pri }
+    };
 
     gFgNhgOrch = new FgNhgOrch(m_configDb, m_stateDb, fgnhg_tables, gNeighOrch, gIntfsOrch, vrf_orch);
     gDirectory.set(gFgNhgOrch);

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -362,11 +362,14 @@ namespace aclorch_test
             gNeighOrch = new NeighOrch(m_app_db.get(), APP_NEIGH_TABLE_NAME, gIntfsOrch);
 
             ASSERT_EQ(gFgNhgOrch, nullptr);
-            vector<string> fgnhg_tables = {
-                CFG_FG_NHG,
-                CFG_FG_NHG_PREFIX,
-                CFG_FG_NHG_MEMBER
+            const int fgnhgorch_pri = 15;
+
+            vector<table_name_with_pri_t> fgnhg_tables = {
+                { CFG_FG_NHG,                 fgnhgorch_pri },
+                { CFG_FG_NHG_PREFIX,          fgnhgorch_pri },
+                { CFG_FG_NHG_MEMBER,          fgnhgorch_pri }
             };
+
             gFgNhgOrch = new FgNhgOrch(m_config_db.get(), m_state_db.get(), fgnhg_tables, gNeighOrch, gIntfsOrch, gVrfOrch);
 
             ASSERT_EQ(gRouteOrch, nullptr);

--- a/tests/test_fgnhg.py
+++ b/tests/test_fgnhg.py
@@ -288,6 +288,7 @@ class TestFineGrainedNextHopGroup(object):
         for v in fvs:
             if v[0] == "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID":
                 nhgid = v[1]
+                print nhgid
 
         (status, fvs) = nhgtbl.get(nhgid)
         assert status
@@ -407,6 +408,63 @@ class TestFineGrainedNextHopGroup(object):
         verify_programmed_nh_membs(adb,nh_memb_exp_count,nh_oid_map,nhgid,bucket_size)
         nh__exp_count = {"10.0.0.1@Ethernet0":10, "10.0.0.3@Ethernet4":10,"10.0.0.5@Ethernet8":10, "10.0.0.7@Ethernet12":10, "10.0.0.9@Ethernet16":10,"10.0.0.11@Ethernet20":10}
         swss_get_route_entry_state(state_db, nh__exp_count)
+
+        print "########################test warm reboot#########################################"
+        #############################################################################
+        #                                                                           #
+        #                        swss Warm-Restart Testing Begin                    #
+        #                                                                           #
+        #############################################################################
+        dvs.runcmd("config warm_restart enable swss")
+
+        # Stop swss before modifing the configDB
+        dvs.stop_swss()
+        time.sleep(1)
+
+        # start to apply new port_config.ini
+        dvs.start_swss()
+        dvs.runcmd(['sh', '-c', 'supervisorctl start neighsyncd'])
+        dvs.runcmd(['sh', '-c', 'supervisorctl start restore_neighbors'])
+        
+        # Enabling some extra logging for validating the order of orchagent
+        dvs.runcmd("swssloglevel -l INFO -c orchagent")
+        time.sleep(5)
+
+        # assert the route points to next hop group
+        (status, fvs) = rtbl.get(k)
+
+        for v in fvs:
+            if v[0] == "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID":
+                nhgid = v[1]
+
+        (status, fvs) = nhgtbl.get(nhgid)
+        assert status
+
+        keys = nhg_member_tbl.getKeys()
+        assert len(keys) == bucket_size
+
+        # Obtain oids of NEXT_HOP asic entries
+        nh_oid_map = {}
+
+        for tbs in nbtbl.getKeys():
+            (status, fvs) = nbtbl.get(tbs)
+            assert status == True
+            for fv in fvs:
+                if fv[0] == "SAI_NEXT_HOP_ATTR_IP":
+                    nh_oid_map[tbs] = fv[1]
+
+        nh_memb_exp_count = {"10.0.0.1":10,"10.0.0.3":10,"10.0.0.5":10,"10.0.0.7":10,"10.0.0.9":10,"10.0.0.11":10}
+        verify_programmed_nh_membs(adb,nh_memb_exp_count,nh_oid_map,nhgid,bucket_size)
+        nh__exp_count = {"10.0.0.1@Ethernet0":10, "10.0.0.3@Ethernet4":10,"10.0.0.5@Ethernet8":10, "10.0.0.7@Ethernet12":10, "10.0.0.9@Ethernet16":10,"10.0.0.11@Ethernet20":10}
+        swss_get_route_entry_state(state_db, nh__exp_count)
+
+        print "########################Recover from warm reboot#########################################"
+
+        #############################################################################
+        #                                                                           #
+        #                        swss Warm-Restart Testing END                      #
+        #                            get to normal state                            #
+        #############################################################################
 
         # Test bank down
         fvs = swsscommon.FieldValuePairs([("nexthop","10.0.0.1,10.0.0.3,10.0.0.5"), ("ifname", "Ethernet0,Ethernet4,Ethernet8")])
@@ -810,10 +868,12 @@ class TestFineGrainedNextHopGroup(object):
                 ("bank", "0"),
             ],
         )
+        
         dvs.runcmd("arp -s 10.0.0.13 00:00:00:00:00:13")
         dvs.runcmd("arp -s 10.0.0.15 00:00:00:00:00:15")
         dvs.runcmd("arp -s 10.0.0.17 00:00:00:00:00:17")
         dvs.runcmd("arp -s 10.0.0.19 00:00:00:00:00:19")
+        time.sleep(1)
 
         db = swsscommon.DBConnector(0, dvs.redis_sock, 0)
         ps = swsscommon.ProducerStateTable(db, "ROUTE_TABLE")


### PR DESCRIPTION


After warm reboot, it is expected that the fgnhg local structure and bucket is retained. 

Changes:
1. Add bake() functions in FgnhgOrch
   bake() function retrieves the state database information
   so that when the new route is added, fgnhg orch is able to recover
   the nexthop and bucket the same as before warm reboot.
2. Add priority to fgnhg tables so that fgnhg tables can be loaded prior to route table.

